### PR TITLE
Upgrade longhorn-system chart to 1.10.2

### DIFF
--- a/system/longhorn-system/Chart.yaml
+++ b/system/longhorn-system/Chart.yaml
@@ -3,5 +3,5 @@ name: longhorn
 version: 0.0.0
 dependencies:
   - name: longhorn
-    version: 1.9.1
+    version: 1.10.2
     repository: https://charts.longhorn.io

--- a/system/longhorn-system/values.yaml
+++ b/system/longhorn-system/values.yaml
@@ -27,11 +27,13 @@ longhorn:
     # -- Setting that allows Longhorn to perform upgrade version checks after starting the Longhorn Manager DaemonSet Pods. Disabling this setting also disables `preUpgradeChecker.jobEnabled`. Longhorn recommends keeping this setting enabled.
     upgradeVersionCheck: true
 
-  defaultSettings:
+  defaultBackupStore:
     # -- Endpoint used to access the backupstore. (Options: "NFS", "CIFS", "AWS", "GCP", "AZURE")
     backupTarget: s3://longhorn-backups@us-east-1/
     # -- Name of the Kubernetes secret associated with the backup target.
     backupTargetCredentialSecret: longhorn-backup-target-credential-secret
+
+  defaultSettings:
     # -- Setting that allows Longhorn to automatically attach a volume and create snapshots or backups when recurring jobs are run.
     allowRecurringJobWhileVolumeDetached: ~
     # -- Default path for storing data on a host. The default value is "/var/lib/longhorn/".


### PR DESCRIPTION
### Summary
- application path: `system/longhorn-system`
- chart name: `longhorn`
- previous version: `1.9.1`
- new version: `1.10.2`

### What changed
- modified `system/longhorn-system/Chart.yaml`
- modified `system/longhorn-system/values.yaml`
- moved backup target configuration from `longhorn.defaultSettings.*` to `longhorn.defaultBackupStore.*`
- generated manifests were not refreshed in this diff

### Breaking changes and review notes
- manual review: check Longhorn CRD `storedVersions` before upgrading to `1.10.x`
- manual review: verify backup target behavior after rollout, especially backup target access and credential secret wiring
- no other application changes are included in this diff
- validation completed, but rollout behavior in-cluster still needs confirmation

### Validation
- passed: `helm dependency build system/longhorn-system`
- passed: `helm lint system/longhorn-system`
- passed: `helm template` on a temp copy of `system/longhorn-system`
- passed: `kubectl kustomize system/longhorn-system | kubectl apply --dry-run=client -f -`

### Checklist
- [ ] review `Chart.yaml` version bump
- [ ] review `values.yaml` migration
- [ ] review generated manifests if changed
- [ ] run or confirm validation commands
- [ ] confirm no unrelated files are included