### PR TITLE
chore: upgrade argocd from 9.4.7 to 9.5.2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,64 @@
+# Claude Code Instructions — homelab-pi-k3s
+
+## Repo structure
+This repo manages Helm-based app deployments on a k3s cluster using Flux or similar GitOps tooling.
+Each app lives under a directory (e.g. `kubernetes/apps/<app-name>/`) and typically contains:
+- `helmrelease.yaml` (or similar) — defines the chart version currently deployed
+- `values.yaml` — custom overrides on top of the default Helm chart values
+
+## Upgrade workflow
+When asked to upgrade an app, follow these steps **in order**:
+
+### Step 1 — Identify current version
+- Find the app directory and read the chart version from `helmrelease.yaml` (or equivalent manifest)
+- Note the chart name, repo URL, and current version
+
+### Step 2 — Compare custom values vs chart defaults
+- Fetch the default `values.yaml` from the Helm chart at the **current** version (use `helm show values <repo>/<chart> --version <current>`)
+- Diff it against the local `values.yaml` to identify custom overrides
+- Save this diff mentally — it must be preserved in the upgrade
+
+### Step 3 — Find latest version
+- Run `helm repo update` and `helm search repo <chart> --versions` to find the latest stable version
+- Fetch the default `values.yaml` for the **latest** version
+- Compare it against the current version's defaults to detect:
+  - Renamed or removed keys → add a `# TODO: BREAKING CHANGE — <key> removed/renamed, see <changelog URL>` comment in values.yaml
+  - New required values → incorporate them with sensible defaults or a TODO
+  - Structural changes
+
+### Step 4 — Apply the upgrade
+- Update the chart version in `helmrelease.yaml`
+- Merge the custom overrides into the new default structure, preserving all custom config
+- Add `# TODO` comments for any breaking changes that need manual review
+
+### Step 5 — Git branch + push
+- Create a branch named `upgrade/<app-name>-<new-version>` (e.g. `upgrade/grafana-8.3.1`)
+- Commit all changes with message: `chore: upgrade <app> from <old> to <new>`
+- Push the branch
+
+### Step 6 — Check release notes
+- Look up the GitHub releases or changelog for the chart/app between the old and new version
+- Identify: breaking changes, manual migration steps, deprecations, security advisories
+- Summarize findings for the PR description
+
+### Step 7 — Create PR
+- Create a PR from the upgrade branch to `main`
+- PR title: `chore: upgrade <app> from <old-version> to <new-version>`
+- PR body must include:
+  - Summary of what changed
+  - List of preserved custom config
+  - Any breaking changes or manual steps needed (with links to docs/release notes)
+  - Any TODO items added to the code
+- Output the PR URL at the end
+
+## Tools available
+- `helm` CLI
+- `gh` CLI (GitHub CLI, already authenticated)
+- `git`
+- `curl` / `wget` for fetching changelogs if needed
+
+## Important rules
+- NEVER remove custom configuration without explicit user confirmation
+- Always add `# TODO` comments rather than silently dropping unknown config
+- Prefer stable/non-RC versions unless asked otherwise
+- Do not touch other apps outside the one being upgraded

--- a/platform/argocd/Chart.yaml
+++ b/platform/argocd/Chart.yaml
@@ -3,5 +3,5 @@ name: argocd
 version: 0.0.0
 dependencies:
   - name: argo-cd 
-    version: 9.4.7
+    version: 9.5.2
     repository: https://argoproj.github.io/argo-helm/


### PR DESCRIPTION
## Summary

- Upgrades `argo-cd` Helm chart from `9.4.7` (ArgoCD v3.3.2) to `9.5.2` (ArgoCD v3.3.7)
- No custom configuration changes required — all overrides are preserved

## Preserved custom config

- `global.domain`, `global.env` (TZ), `global.networkPolicy`
- `configs.cm`: exec enabled, admin disabled, reconciliation timeouts, custom RBAC accounts, health Lua, ignoreDifferences
- `configs.params`: controller/server/reposerver/appset tuning
- `configs.rbac`: policy.default + policy.csv
- `configs.ssh.knownHosts`, `configs.cmp.plugins` (argocd-vault-plugin, kustomized-helm, vault-kustomized-helm, vault-kustomized)
- `configs.repositories`: GitHub + Gitea repos
- `extraObjects`: argocd-repo-server SA token, ClusterRoleBinding, vault plugin credentials secret
- `repoServer`: replicas=2, envFrom vault secret, extraContainers (plugin sidecars), initContainers (download argocd-vault-plugin), volumeMounts/volumes
- `server.ingress`: nginx with ssl-passthrough, cert-manager, hajimari annotations
- `notifications`: Discord webhook notifier + all 6 triggers + templates

## Changes between 9.4.7 → 9.5.2

**App version bumps:**
- ArgoCD: v3.3.2 → v3.3.7
- Dex sidecar: v2.44.0 → v2.45.1
- redis-exporter: v1.81.0 → v1.82.0
- argocd-extension-installer: v0.0.9 → v1.0.0

**New chart features (all additive, no action required):**
- VPA (VerticalPodAutoscaler) support added for all components — disabled by default (`vpa.enabled: false`)
- `repoServer.copyutil.extraArgs: "--update=none"` added as new default
- `global.annotations` now includes `argocd.argoproj.io/sync-options: ServerSideApply=true` by default
- `redis.runAsUser: 1001` added to security context

**Notable fixes:**
- 9.4.12: Set `ServerSideApply` sync option annotation on CRDs
- 9.4.14: Fix `runAsUser` omission for Dex on OpenShift
- 9.4.15: Fix VPA `updateMode` YAML boolean coercion

## Breaking changes / Manual steps

None. All changes are additive or internal image bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)