### PR TITLE
chore: upgrade velero from 11.4.0 to 12.0.0

### DIFF
--- a/system/velero/Chart.yaml
+++ b/system/velero/Chart.yaml
@@ -3,5 +3,5 @@ name: velero
 version: 0.0.0
 dependencies:
   - name: velero
-    version: 11.4.0
+    version: 12.0.0
     repository: https://vmware-tanzu.github.io/helm-charts

--- a/system/velero/values.yaml
+++ b/system/velero/values.yaml
@@ -60,9 +60,7 @@ velero:
   kubectl:
     image:
       repository: registry.k8s.io/kubectl
-      # TODO: BREAKING CHANGE — repo moved from docker.io/bitnamilegacy/kubectl to registry.k8s.io/kubectl (velero-12.0.0).
-      # Verify tag format: registry.k8s.io/kubectl uses v-prefixed tags (e.g. v1.33.4). Update if image pull fails.
-      tag: 1.33.4
+      tag: v1.33.4
 
   # This job upgrades the CRDs.
   upgradeCRDs: true

--- a/system/velero/values.yaml
+++ b/system/velero/values.yaml
@@ -59,7 +59,9 @@ velero:
 
   kubectl:
     image:
-      repository: docker.io/bitnamilegacy/kubectl
+      repository: registry.k8s.io/kubectl
+      # TODO: BREAKING CHANGE — repo moved from docker.io/bitnamilegacy/kubectl to registry.k8s.io/kubectl (velero-12.0.0).
+      # Verify tag format: registry.k8s.io/kubectl uses v-prefixed tags (e.g. v1.33.4). Update if image pull fails.
       tag: 1.33.4
 
   # This job upgrades the CRDs.


### PR DESCRIPTION
## Summary

- Upgrades velero Helm chart from `11.4.0` (app `1.17.1`) to `12.0.0` (app `1.18.0`)
- Updates kubectl sidecar image repository from `docker.io/bitnamilegacy/kubectl` to `registry.k8s.io/kubectl` (the only chart-level change in this release)

## Preserved custom config

- `initContainers`: `velero-plugin-for-aws:v1.13.1`
- `metrics`: serviceMonitor + prometheusRule with custom backup failure alerts
- `kubectl.image.tag: 1.33.4`
- `configuration`: backupStorageLocation/volumeSnapshotLocation pointing to minio, `features: EnableCSI`, `TZ: Europe/Madrid`
- `credentials`: velero-minio-credentials secret
- `schedules`: `pi-k3s-complete-backup` daily at 07:45

## Breaking changes / manual steps

- **kubectl image registry change** ([PR #706](https://github.com/vmware-tanzu/helm-charts/pull/706)): The kubectl helper image moved from `docker.io/bitnamilegacy/kubectl` to `registry.k8s.io/kubectl`. A `TODO` comment has been added in `values.yaml` — verify the tag `1.33.4` resolves correctly on the new registry (official images use `v`-prefixed tags like `v1.33.4`). Update the tag if the pod fails to pull.

## TODO items added

- `system/velero/values.yaml`: verify `kubectl.image.tag` format for `registry.k8s.io/kubectl`