### PR TITLE
chore: upgrade longhorn from 1.10.2 to 1.11.1

### DIFF
--- a/system/longhorn-system/Chart.yaml
+++ b/system/longhorn-system/Chart.yaml
@@ -3,5 +3,5 @@ name: longhorn
 version: 0.0.0
 dependencies:
   - name: longhorn
-    version: 1.10.2
+    version: 1.11.1
     repository: https://charts.longhorn.io


### PR DESCRIPTION
## Summary

- Upgrade Longhorn Helm chart from `1.10.2` (app `v1.10.2`) to `1.11.1` (app `v1.11.1`)

## Preserved custom config

- `networkPolicies.type: k3s`
- `persistence.defaultClassReplicaCount: 3`, `reclaimPolicy: Retain`
- `persistence.recurringJobSelector` with snapshot + backup schedule
- `preUpgradeChecker.jobEnabled: false`
- `defaultBackupStore` pointing to S3 with credential secret
- `defaultSettings.defaultDataPath: /data/longhorn`, `concurrentReplicaRebuildPerNodeLimit: 2`, `concurrentVolumeBackupRestorePerNodeLimit: 2`, `allowCollectingLonghornUsageMetrics: false`, `deletingConfirmationFlag: true`, `backupConcurrentLimit: 2`, `restoreConcurrentLimit: 2`
- `longhornUI.replicas: 1`
- `ingress` with nginx, cert-manager, and hajimari annotations
- `metrics.serviceMonitor.enabled: true`

## Breaking changes / manual steps

None for the existing custom configuration. All custom keys are preserved in 1.11.1.

## Notable changes (1.10.2 → 1.11.1)

### v1.11.1 (patch)
- **Critical fix**: Memory leak in `longhorn-instance-manager` pods caused by proxy connection leaks ([#12575](https://github.com/longhorn/longhorn/issues/12575))
- **Backup fix**: Resolved S3-compatible backup compatibility issues (Storj, GCS) after aws-go-sdk v2 migration ([#12714](https://github.com/longhorn/longhorn/issues/12714))
- CSI topology-aware PV nodeAffinity support

### v1.11.0 (minor)
- New optional Helm settings: `global.timezone`, `managerUrl`, `podAntiAffinityPreset`, `systemManagedCSIComponentsResourceLimits`, `endpointNetworkForRWXVolume`, `nodeDiskHealthMonitoring`, `csiAllowedTopologyKeys`, `httproute` section, `longhornManager.updateStrategy`
- V2 Data Engine enters Technical Preview
- aws-go-sdk migrated from v1 to v2
- **Note**: v1.11.0 had two known regressions (instance-manager memory leak, manager CNI deadlock) — both fixed in v1.11.1

## Requirements

- Kubernetes v1.25 or later (already satisfied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)