### PR TITLE
chore: upgrade cloudflare from 2025.8.1 to 2026.3.0

### DIFF
--- a/system/cloudflare/resources/deployment.yaml
+++ b/system/cloudflare/resources/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: cloudflared
-        image: cloudflare/cloudflared:2025.8.1
+        image: cloudflare/cloudflared:2026.3.0
         imagePullPolicy: IfNotPresent
         args: ["tunnel", "--no-autoupdate", "run", "--token=<path:pi-k3s/data/system/cloudflare/tunnel#token>"]
         env:


### PR DESCRIPTION
## Summary

- Bumps `cloudflare/cloudflared` image tag from `2025.8.1` to `2026.3.0`
- Covers releases: 2025.9.0, 2025.9.1, 2025.10.0, 2025.10.1, 2025.11.0, 2025.11.1, 2026.1.1, 2026.1.2, 2026.2.0, 2026.3.0

## Preserved custom config

- `args: ["tunnel", "--no-autoupdate", "run", "--token=..."]` — unchanged
- `TZ: Europe/Madrid` — unchanged
- `restartPolicy: Always`, `terminationGracePeriodSeconds: 60` — unchanged

## Breaking changes / manual steps

No breaking changes identified. Release notes between versions only contain binary checksums. Cloudflared tunnel configuration and CLI flags remain compatible.

## References

- [GitHub Releases](https://github.com/cloudflare/cloudflared/releases)