### PR TITLE
chore: upgrade metallb from 0.15.2 to 0.15.3

### DIFF
--- a/system/metallb-system/Chart.yaml
+++ b/system/metallb-system/Chart.yaml
@@ -3,5 +3,5 @@ name: metallb
 version: 0.0.0
 dependencies:
   - name: metallb
-    version: 0.15.2
+    version: 0.15.3
     repository: https://metallb.github.io/metallb


### PR DESCRIPTION
## Summary

- Bumps metallb Helm chart from `0.15.2` to `0.15.3`
- FRR image upgraded from 9.1.0 to 10.4.1
- No changes required to custom `values.yaml`

## Preserved custom config

- `rbac.create: true`
- `controller.enabled: true` with `nodeSelector` and `tolerations` for master node
- `speaker.enabled: true`
- `crds.enabled: true`

## New features in 0.15.3

- **ConfigurationState CRD** — new CRD to expose configuration errors per MetalLB component (#2881)
- **Network policy support** — new `networkpolicies` section in chart (disabled by default)
- **FRR upgraded to 10.4.1** — includes security fixes
- **Init container resources** — new optional resource config for FRR init containers

## Bug fixes / security

- CVE-2025-22874 fixed in Docker images
- `readOnlyRootFilesystem: true` and `allowPrivilegeEscalation: false` added to previously missing containers
- ARP responder fix for Cilium lxc veth interfaces

## Breaking changes / manual steps

None. All new values are additive with safe defaults.

## References

- [Release notes v0.15.3](https://metallb.universe.tf/release-notes/#version-0-15-3)