### PR TITLE
chore: upgrade uptime-kuma from 2.0.2 to 2.2.1

### DIFF
--- a/system/monitoring-system/uptime-kuma/values.yaml
+++ b/system/monitoring-system/uptime-kuma/values.yaml
@@ -1,7 +1,7 @@
 uptime-kuma:
   image:
     repository: louislam/uptime-kuma
-    tag: 2.0.2-slim
+    tag: 2.2.1-slim
 
   env:
     TZ: Europe/Madrid


### PR DESCRIPTION
## Summary
- Bumped `louislam/uptime-kuma` image tag from `2.0.2-slim` to `2.2.1-slim`
- Chart is deprecated; upgrade is image-tag only

## Preserved custom config
- `env.TZ`, `env.UPTIME_KUMA_DISABLE_FRAME_SAMEORIGIN`
- Ingress with cert-manager, hajimari annotations, nginx class
- Longhorn persistence (5Gi)

## Changes between 2.0.2 → 2.2.1
- **2.2.1**: Security fix for SSTI in Notification Templates (GHSA-v832-4r73-wx5j), new Fluxer notification provider, bug fixes for prometheus metrics removal regression
- **2.1.x**: Various bug fixes and dependency updates (see [releases](https://github.com/louislam/uptime-kuma/releases))

## Breaking changes / manual steps
None identified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)