### PR TITLE
chore: upgrade unifi-poller from v2.15.4 to v2.39.0

### DIFF
--- a/system/monitoring-system/unifi-poller/values.yaml
+++ b/system/monitoring-system/unifi-poller/values.yaml
@@ -2,7 +2,7 @@ unifi-poller:
   image:
     repository: ghcr.io/unpoller/unpoller
     pullPolicy: IfNotPresent
-    tag: v2.15.4
+    tag: v2.39.0
 
 
   # -- Environment variable configuration options for unifi-poller ([docs](https://unifipoller.com/docs/install/configuration)).


### PR DESCRIPTION
## Summary
- Bumped `ghcr.io/unpoller/unpoller` image tag from `v2.15.4` to `v2.39.0`
- Chart is deprecated; upgrade is image-tag only

## Preserved custom config
- Service metrics port (9130)
- Ingress with cert-manager, hajimari annotations, nginx class
- Secret-based config persistence (`unifi-poller-config`)
- ServiceMonitor and PrometheusRule for `UnifiPollerAbsent` alert

## Changes between v2.15.4 → v2.39.0
Large version jump (24 minor releases). See full changelog: https://github.com/unpoller/unpoller/releases

## Breaking changes / manual steps
None identified — review release notes for any config file format changes if issues arise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)