### PR TITLE
chore: upgrade loki from 2.10.2 to 2.10.3

### DIFF
--- a/system/monitoring-system/loki/Chart.yaml
+++ b/system/monitoring-system/loki/Chart.yaml
@@ -3,5 +3,5 @@ name: loki
 version: 0.0.0
 dependencies:
   - name: loki-stack
-    version: 2.10.2
+    version: 2.10.3
     repository: https://grafana.github.io/helm-charts


### PR DESCRIPTION
## Summary
- Bumped `loki-stack` chart from `2.10.2` to `2.10.3` (app version remains `v2.9.3`)

## Preserved custom config
- Loki with S3/MinIO storage backend (boltdb-shipper)
- Custom retention (240h), schema config, compactor
- Trusted CA secret volume mount for MinIO TLS
- Promtail enabled with custom log level and push URL

## Breaking changes / manual steps
No default values changed between 2.10.2 and 2.10.3. Patch release only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)