### PR TITLE
chore: upgrade ingress-nginx from 4.13.1 to 4.15.1

### DIFF
--- a/system/ingress-nginx/Chart.yaml
+++ b/system/ingress-nginx/Chart.yaml
@@ -3,5 +3,5 @@ name: ingress-nginx
 version: 0.0.0
 dependencies:
   - name: ingress-nginx
-    version: 4.13.1
+    version: 4.15.1
     repository: https://kubernetes.github.io/ingress-nginx


### PR DESCRIPTION
## Summary
- Bumped `ingress-nginx` chart from `4.13.1` to `4.15.1` (app version `v1.13.1` → `v1.15.1`)

## Preserved custom config
- SSL passthrough enabled (`enable-ssl-passthrough: "true"`)
- Fixed LoadBalancer IP (`192.168.40.200`)
- TZ environment variable (`Europe/Madrid`)
- Metrics and ServiceMonitor enabled

## Changes between 4.13.1 → 4.15.1
- Controller image bumped `v1.13.1` → `v1.15.1`
- Admission webhook image bumped `v1.6.1` → `v1.6.9`
- New optional `resizePolicy` field for controller containers (Kubernetes in-place resource resize)
- New optional `volumeMounts`/`volumes` fields for admission webhook jobs
- New optional `scrapeTimeout` for ServiceMonitor
- All new fields are additive and optional — no action required

## Breaking changes / manual steps
None. Full changelog: https://github.com/kubernetes/ingress-nginx/releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)