### PR TITLE
chore: upgrade cert-manager from 1.18.2 to v1.20.2

### DIFF
--- a/system/cert-manager/Chart.yaml
+++ b/system/cert-manager/Chart.yaml
@@ -3,5 +3,5 @@ name: cert-manager
 version: 0.0.0
 dependencies:
   - name: cert-manager
-    version: 1.18.2
+    version: v1.20.2
     repository: https://charts.jetstack.io


### PR DESCRIPTION
## Summary
- Bumped `cert-manager` chart from `1.18.2` to `v1.20.2` (two minor versions)

## Preserved custom config
- `installCRDs: true`
- DNS01 recursive nameservers (Cloudflare + Google) with `--dns01-recursive-nameservers-only`
- Custom pod DNS policy/config pointing to `1.1.1.1` / `8.8.8.8`
- Master node tolerations for controller, webhook, cainjector, startupapicheck
- Prometheus ServiceMonitor enabled

## Notable changes between v1.18.2 → v1.20.2
- **New global `imageRegistry`/`imageNamespace` fields** replacing per-component `registry` prefix (old `image.registry` deprecated but still works)
- **`OtherNames` feature gate** promoted ALPHA → BETA, now enabled by default (`true`)
- **`ACMEHTTP01IngressPathTypeExact`** remains BETA default-true
- **Removed GA feature gates**: `AdditionalCertificateOutputFormats`, `UseDomainQualifiedFinalizer`, `DefaultPrivateKeyRotationPolicyAlways`, `ValidateCAA` (no action needed, they were already defaults)
- **Webhook network policy** ingress rules changed from open `0.0.0.0/0` to port-based rules (only affects if `networkPolicy.enabled: true`, which it isn't here)
- **New optional fields**: `networkPolicy` (disabled by default), `global.nodeSelector`, `resizePolicy`, `pemSizeLimitsConfig`, `webhook.enableClientVerification`

## Breaking changes / manual steps
None for this configuration. Full changelog:
- https://github.com/cert-manager/cert-manager/releases/tag/v1.19.0
- https://github.com/cert-manager/cert-manager/releases/tag/v1.20.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)