### PR TITLE
chore: upgrade homepage from 11.12.1 to 12.2.1

### DIFF
--- a/apps/dashboards/homepage/Chart.yaml
+++ b/apps/dashboards/homepage/Chart.yaml
@@ -3,5 +3,5 @@ name: homepage
 version: 0.0.0
 dependencies:
   - name: homepage
-    version: 11.12.1
+    version: 12.2.1
     repository: oci://oci.trueforge.org/truecharts


### PR DESCRIPTION
## Summary
- Bumped TrueCharts `homepage` chart from `11.12.1` to `12.2.1`
- Homepage app image bumped `v1.5.0` → `v1.12.3`

## Preserved custom config
- Custom init container (`init-config`) with `imageSelector: alpineImage` — unaffected by chart default changing to `ubuntuImage`
- All configmap data: services, widgets, bookmarks, settings, kubernetes config
- Longhorn persistence (5Gi), ingress with cert-manager, nginx class
- `forceConfigFromValues: true`
- ServiceAccount, RBAC for Kubernetes cluster discovery

## Breaking changes / manual steps
None. The chart default for the init container changed from `alpineImage` to `ubuntuImage`, but our values explicitly override this with `imageSelector: alpineImage` so there is no impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)