### PR TITLE
chore: upgrade pod-info from 6.9.1 to 6.11.2

### DIFF
--- a/apps/pod-info/resources/deployment.yaml
+++ b/apps/pod-info/resources/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: pod-info
-        image: stefanprodan/podinfo:6.9.1
+        image: stefanprodan/podinfo:6.11.2
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9898


### PR DESCRIPTION
## Summary
- Bumped `stefanprodan/podinfo` image tag from `6.9.1` to `6.11.2` in `deployment.yaml`

## Preserved custom config
- Single replica, port 9898, `IfNotPresent` pull policy

## Breaking changes / manual steps
None. Full changelog: https://github.com/stefanprodan/podinfo/releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)