### PR TITLE
chore: upgrade myspeed from 1.11.1 to 2.1.1

### DIFF
--- a/apps/myspeed/Chart.yaml
+++ b/apps/myspeed/Chart.yaml
@@ -3,5 +3,5 @@ name: myspeed
 version: 0.0.0
 dependencies:
   - name: myspeed
-    version: 1.11.1
+    version: 2.1.1
     repository: oci://oci.trueforge.org/truecharts


### PR DESCRIPTION
## Summary
- Bumped TrueCharts `myspeed` chart from `1.11.1` to `2.1.1`

## Preserved custom config
- Service port 5216, ingress with cert-manager and nginx
- Longhorn persistence (5Gi, `/myspeed/data`)
- ServiceMonitor with Prometheus metrics endpoint (`/api/prometheus/metrics`)

## Breaking changes / manual steps
None. No default values changed between versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)