### PR TITLE
chore: upgrade octoprint from 1.11.2 to 1.11.7

### DIFF
--- a/apps/octoprint/values.yaml
+++ b/apps/octoprint/values.yaml
@@ -1,7 +1,7 @@
 octoprint:
   image:
     repository: octoprint/octoprint
-    tag: 1.11.2
+    tag: 1.11.7
 
   env:
     TZ: Europe/Madrid


### PR DESCRIPTION
## Summary
- Bumped `octoprint/octoprint` image tag from `1.11.2` to `1.11.7`
- Chart is deprecated (k8s-at-home); upgrade is image-tag only

## Preserved custom config
- Node selector (`pi-kube-worker-0`)
- Privileged security context (USB device access)
- HostPath mounts: printer (`/dev/ttyUSB0`), `vcgencmd`, `libvcos.so.0`, `libvchiq_arm.so.0`
- Longhorn persistence (5Gi, `/octoprint`)
- Ingress with cert-manager, hajimari annotations, 50m proxy body size

## Breaking changes / manual steps
None. Full changelog: https://github.com/OctoPrint/OctoPrint/releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)