### PR TITLE
chore: upgrade romm from 14.20.3 to 17.2.3

### DIFF
--- a/apps/romm/Chart.yaml
+++ b/apps/romm/Chart.yaml
@@ -3,5 +3,5 @@ name: romm
 version: 0.0.0
 dependencies:
   - name: romm
-    version: 14.20.3
+    version: 17.2.3
     repository: oci://oci.trueforge.org/truecharts


### PR DESCRIPTION
## Summary
- Bumped TrueCharts `romm` chart from `14.20.3` to `17.2.3`
- RomM app image bumped from `4.3` to `4.8`

## Preserved custom config
- Custom `mariadbClientImage` and `redisClientImage` (arm64-compatible images)
- NFS-backed persistence for library, resources, assets (2Ti each, `nfs-roms`)
- Longhorn persistence for config and MariaDB data
- IGDB, SteamGridDB API keys, auth secret via Vault paths
- MariaDB and Redis with `bitnami/...:latest` (arm64 workaround)
- HTTP probes, `ENABLE_EXPERIMENTAL_REDIS`, `ROMM_BASE_PATH`

## Breaking changes / manual steps
None. No default value structure changes between versions. Full changelog: https://github.com/rommapp/romm/releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)