### PR TITLE
Add peaNUT UPS dashboard app

### DIFF
--- a/apps/dashboards/homepage/values.yaml
+++ b/apps/dashboards/homepage/values.yaml
@@ -611,6 +611,12 @@ homepage:
                   description: Kubernetes Native Object Storage
                   siteMonitor: https://192.168.40.250:9002/
                   statusStyle: 'basic'
+              - Peanut:
+                  icon: peanut.png
+                  href: https://peanut.local.tecno-fly.com/
+                  description: UPS Dashboard (Network UPS Tools)
+                  namespace: peanut
+                  app: peanut
 
           - Games:
               - Romm:

--- a/apps/peanut/Chart.yaml
+++ b/apps/peanut/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: peanut
+version: 0.0.0
+dependencies:
+  - name: peanut
+    version: 10.5.0
+    repository: oci://oci.trueforge.org/truecharts

--- a/apps/peanut/kustomization.yaml
+++ b/apps/peanut/kustomization.yaml
@@ -1,0 +1,4 @@
+namespace: peanut
+
+resources:
+- ./resources/all.yaml

--- a/apps/peanut/values.yaml
+++ b/apps/peanut/values.yaml
@@ -1,0 +1,46 @@
+peanut:
+  podOptions:
+    nodeSelector:
+      kubernetes.io/arch: null
+
+  ingress:
+    main:
+      enabled: true
+
+      annotations:
+        cert-manager.io/cluster-issuer: letsencrypt-prod
+        # kubernetes.io/tls-acme: "true"
+
+      ingressClassName: "nginx"
+
+      hosts:
+        - host: peanut.local.tecno-fly.com
+          paths:
+            - path: /
+              pathType: Prefix
+              service:
+                name: peanut
+                port: 10688
+      tls:
+        - secretName: peanut-tls
+          hosts:
+            - peanut.local.tecno-fly.com
+      integrations:
+        traefik:
+          enabled: false
+
+  persistence:
+    config:
+      enabled: true
+      storageClass: longhorn
+      size: 1Gi
+      mountPath: "/config"
+
+  workload:
+    main:
+      podSpec:
+        containers:
+          main:
+            env:
+              WEB_USERNAME: <path:pi-k3s/data/apps/peanut#user>
+              WEB_PASSWORD: <path:pi-k3s/data/apps/peanut#pass>


### PR DESCRIPTION
## Summary
- Deploys [peaNUT](https://truecharts.org/charts/stable/peanut/) (TrueCharts `stable/peanut` chart v10.5.0), a dashboard for Network UPS Tools (NUT), following the same standalone-app folder structure as `myspeed`/`romm`/`octoprint` (`Chart.yaml` OCI dependency + `kustomization.yaml` + `values.yaml` + empty `resources/`).
- Ingress at `peanut.local.tecno-fly.com` (nginx, `letsencrypt-prod`, TLS secret `peanut-tls`).
- `/config` persisted on `longhorn`, 1Gi (small footprint — only stores `settings.yml`).
- Built-in web auth enabled via `WEB_USERNAME`/`WEB_PASSWORD`, sourced from Vault at `pi-k3s/data/apps/peanut#user` / `#pass`.
- `podOptions.nodeSelector.kubernetes.io/arch: null` to allow scheduling on the arm64 Pi nodes (same override used by other TrueCharts apps in this repo).
- Adds a "Peanut" tile to the Homepage dashboard under the NAS section (Network tab), linking to the new ingress host with a pod status badge. No custom Homepage widget exists for peaNUT, so it's a plain link tile (like the existing MinIO entry).

## Notes
- peaNUT doesn't take a NUT-server connection via chart values — after first deploy, log in at `https://peanut.local.tecno-fly.com/` and add the NUT server (host/port/UPS name) through the web UI; it persists to the `/config` volume.
- Before merging, make sure the `pi-k3s/data/apps/peanut` Vault secret (`user`/`pass` keys) exists, or the pod will fail to start with unresolved `<path:...>` placeholders.

## Test plan
- [x] `helm dependency update` + `helm template` rendered cleanly (PVC, Service, Deployment with auth env vars, Ingress with correct host).
- [ ] ArgoCD sync succeeds and pod comes up healthy.
- [ ] Ingress reachable at `https://peanut.local.tecno-fly.com/` and login works with the Vault-stored credentials.
- [ ] Homepage tile renders and status badge reflects pod health.

🤖 Generated with [Claude Code](https://claude.com/claude-code)