### PR TITLE
fix: migrate external-endpoints from Endpoints to EndpointSlice

### DIFF
--- a/apps/external-endpoints/resources/jellyfin.yaml
+++ b/apps/external-endpoints/resources/jellyfin.yaml
@@ -13,18 +13,21 @@ spec:
   clusterIP: None
   type: ClusterIP
 ---
-apiVersion: v1
-kind: Endpoints
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
 metadata:
   name: jellyfin-external-service
   namespace: external-endpoints
-subsets:
+  labels:
+    kubernetes.io/service-name: jellyfin-external-service
+addressType: IPv4
+ports:
+- name: http
+  port: 30013
+  protocol: TCP
+endpoints:
 - addresses:
-  - ip: 192.168.40.250
-  ports:
-  - name: http
-    port: 30013
-    protocol: TCP
+  - 192.168.40.250
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/apps/external-endpoints/resources/minio.yaml
+++ b/apps/external-endpoints/resources/minio.yaml
@@ -13,18 +13,21 @@ spec:
   clusterIP: None
   type: ClusterIP
 ---
-apiVersion: v1
-kind: Endpoints
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
 metadata:
   name: minio-external-service
   namespace: external-endpoints
-subsets:
+  labels:
+    kubernetes.io/service-name: minio-external-service
+addressType: IPv4
+ports:
+- name: http
+  port: 9002
+  protocol: TCP
+endpoints:
 - addresses:
-  - ip: 192.168.40.250
-  ports:
-  - name: http
-    port: 9002
-    protocol: TCP
+  - 192.168.40.250
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/apps/external-endpoints/resources/netdata.yaml
+++ b/apps/external-endpoints/resources/netdata.yaml
@@ -13,18 +13,21 @@ spec:
   clusterIP: None
   type: ClusterIP
 ---
-apiVersion: v1
-kind: Endpoints
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
 metadata:
   name: netdata-external-service
   namespace: external-endpoints
-subsets:
+  labels:
+    kubernetes.io/service-name: netdata-external-service
+addressType: IPv4
+ports:
+- name: http
+  port: 20489
+  protocol: TCP
+endpoints:
 - addresses:
-  - ip: 192.168.40.250
-  ports:
-  - name: http
-    port: 20489
-    protocol: TCP
+  - 192.168.40.250
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/apps/external-endpoints/resources/pi-hole-0.yaml
+++ b/apps/external-endpoints/resources/pi-hole-0.yaml
@@ -13,18 +13,21 @@ spec:
   clusterIP: None
   type: ClusterIP
 ---
-apiVersion: v1
-kind: Endpoints
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
 metadata:
   name: pi-hole-0-service
   namespace: external-endpoints
-subsets:
+  labels:
+    kubernetes.io/service-name: pi-hole-0-service
+addressType: IPv4
+ports:
+- name: http
+  port: 80
+  protocol: TCP
+endpoints:
 - addresses:
-  - ip: 192.168.40.254
-  ports:
-  - name: http
-    port: 80
-    protocol: TCP
+  - 192.168.40.254
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/apps/external-endpoints/resources/pi-hole-truenas.yaml
+++ b/apps/external-endpoints/resources/pi-hole-truenas.yaml
@@ -13,18 +13,21 @@ spec:
   clusterIP: None
   type: ClusterIP
 ---
-apiVersion: v1
-kind: Endpoints
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
 metadata:
   name: pi-hole-truenas-service
   namespace: external-endpoints
-subsets:
+  labels:
+    kubernetes.io/service-name: pi-hole-truenas-service
+addressType: IPv4
+ports:
+- name: http
+  port: 20720
+  protocol: TCP
+endpoints:
 - addresses:
-  - ip: 192.168.40.250
-  ports:
-  - name: http
-    port: 20720
-    protocol: TCP
+  - 192.168.40.250
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/apps/external-endpoints/resources/pi-home-assistant.yaml
+++ b/apps/external-endpoints/resources/pi-home-assistant.yaml
@@ -13,18 +13,21 @@ spec:
   clusterIP: None
   type: ClusterIP
 ---
-apiVersion: v1
-kind: Endpoints
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
 metadata:
   name: pi-home-assistant-service
   namespace: external-endpoints
-subsets:
+  labels:
+    kubernetes.io/service-name: pi-home-assistant-service
+addressType: IPv4
+ports:
+- name: http
+  port: 8123
+  protocol: TCP
+endpoints:
 - addresses:
-  - ip: 192.168.60.250
-  ports:
-  - name: http
-    port: 8123
-    protocol: TCP
+  - 192.168.60.250
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/apps/external-endpoints/resources/plex.yaml
+++ b/apps/external-endpoints/resources/plex.yaml
@@ -13,18 +13,21 @@ spec:
   clusterIP: None
   type: ClusterIP
 ---
-apiVersion: v1
-kind: Endpoints
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
 metadata:
   name: plex-external-service
   namespace: external-endpoints
-subsets:
+  labels:
+    kubernetes.io/service-name: plex-external-service
+addressType: IPv4
+ports:
+- name: http
+  port: 32400
+  protocol: TCP
+endpoints:
 - addresses:
-  - ip: 192.168.40.250
-  ports:
-  - name: http
-    port: 32400
-    protocol: TCP
+  - 192.168.40.250
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/apps/external-endpoints/resources/qbittorrent.yaml
+++ b/apps/external-endpoints/resources/qbittorrent.yaml
@@ -13,18 +13,21 @@ spec:
   clusterIP: None
   type: ClusterIP
 ---
-apiVersion: v1
-kind: Endpoints
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
 metadata:
   name: qbittorrent-external-service
   namespace: external-endpoints
-subsets:
+  labels:
+    kubernetes.io/service-name: qbittorrent-external-service
+addressType: IPv4
+ports:
+- name: http
+  port: 10095
+  protocol: TCP
+endpoints:
 - addresses:
-  - ip: 192.168.40.250
-  ports:
-  - name: http
-    port: 10095
-    protocol: TCP
+  - 192.168.40.250
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/apps/external-endpoints/resources/s3.yaml
+++ b/apps/external-endpoints/resources/s3.yaml
@@ -13,18 +13,21 @@ spec:
   clusterIP: None
   type: ClusterIP
 ---
-apiVersion: v1
-kind: Endpoints
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
 metadata:
   name: s3-external-service
   namespace: external-endpoints
-subsets:
+  labels:
+    kubernetes.io/service-name: s3-external-service
+addressType: IPv4
+ports:
+- name: http
+  port: 9000
+  protocol: TCP
+endpoints:
 - addresses:
-  - ip: 192.168.40.250
-  ports:
-  - name: http
-    port: 9000
-    protocol: TCP
+  - 192.168.40.250
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/apps/external-endpoints/resources/truenas-browser.yaml
+++ b/apps/external-endpoints/resources/truenas-browser.yaml
@@ -13,18 +13,21 @@ spec:
   clusterIP: None
   type: ClusterIP
 ---
-apiVersion: v1
-kind: Endpoints
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
 metadata:
   name: truenas-browser-external-service
   namespace: external-endpoints
-subsets:
+  labels:
+    kubernetes.io/service-name: truenas-browser-external-service
+addressType: IPv4
+ports:
+- name: http
+  port: 30044
+  protocol: TCP
+endpoints:
 - addresses:
-  - ip: 192.168.40.250
-  ports:
-  - name: http
-    port: 30044
-    protocol: TCP
+  - 192.168.40.250
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/apps/external-endpoints/resources/truenas.yaml
+++ b/apps/external-endpoints/resources/truenas.yaml
@@ -13,18 +13,21 @@ spec:
   clusterIP: None
   type: ClusterIP
 ---
-apiVersion: v1
-kind: Endpoints
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
 metadata:
   name: truenas-external-service
   namespace: external-endpoints
-subsets:
+  labels:
+    kubernetes.io/service-name: truenas-external-service
+addressType: IPv4
+ports:
+- name: http
+  port: 443
+  protocol: TCP
+endpoints:
 - addresses:
-  - ip: 192.168.40.250
-  ports:
-  - name: http
-    port: 443
-    protocol: TCP
+  - 192.168.40.250
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/apps/external-endpoints/resources/unifi.yaml
+++ b/apps/external-endpoints/resources/unifi.yaml
@@ -13,18 +13,21 @@ spec:
   clusterIP: None
   type: ClusterIP
 ---
-apiVersion: v1
-kind: Endpoints
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
 metadata:
   name: unifi-external-service
   namespace: external-endpoints
-subsets:
+  labels:
+    kubernetes.io/service-name: unifi-external-service
+addressType: IPv4
+ports:
+- name: http
+  port: 443
+  protocol: TCP
+endpoints:
 - addresses:
-  - ip: 192.168.0.1
-  ports:
-  - name: http
-    port: 443
-    protocol: TCP
+  - 192.168.0.1
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress


### PR DESCRIPTION
## Summary
- The `v1 Endpoints` API is deprecated in Kubernetes 1.33+; this replaces all manual `Endpoints` objects under `apps/external-endpoints/resources/` with the `discovery.k8s.io/v1 EndpointSlice` equivalent.
- Each `EndpointSlice` carries the required `kubernetes.io/service-name` label to bind it to its corresponding selector-less `Service` (these Services have no pod selector, so Kubernetes can't auto-generate the EndpointSlice — it must be supplied manually, same as before with `Endpoints`).
- `Service` and `Ingress` objects are untouched; only the middle `Endpoints` → `EndpointSlice` document in each file changed.

Files changed (12): jellyfin, minio, netdata, pi-hole-0, pi-hole-truenas, pi-home-assistant, plex, qbittorrent, s3, truenas-browser, truenas, unifi.

Note: `pi-home-assistant.yaml` is present in the directory but not referenced by `kustomization.yaml`, so it's currently not deployed — updated for consistency but flagging in case that's intentional/unintentional.

## Preserved config
- All service names, ports, protocols, and target IPs preserved exactly.
- `addressType: IPv4` set explicitly (required field, was implicit before).

## Manual verification
- All 12 manifests validated via `kubectl apply --dry-run=server` against the live cluster — accepted cleanly with no schema errors.

## Notes / follow-up
- Since this repo is ArgoCD-managed, the old `Endpoints` objects should be pruned automatically on sync if pruning is enabled on the Application (kind changed, so they're no longer present in the rendered manifests). Worth confirming pruning is on for the `external-endpoints` Application so the old objects don't linger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)